### PR TITLE
feat: Add dependency tracking for pug templates

### DIFF
--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -21,5 +21,8 @@ test('should allow to use .pug template file', async ({ page }) => {
 	const testEl = page.locator('#test');
 	await expect(testEl).toHaveText('Hello Rsbuild!');
 
+	const dependencyEl = page.locator('#dependency');
+	await expect(dependencyEl).toHaveText('dependency text');
+
 	await server.close();
 });

--- a/test/basic/src/dependency.pug
+++ b/test/basic/src/dependency.pug
@@ -1,0 +1,1 @@
+#dependency dependency text

--- a/test/basic/src/index.pug
+++ b/test/basic/src/index.pug
@@ -1,2 +1,3 @@
 p(id="test-pug") Pug source code!
 div(id="root")
+include ./dependency

--- a/test/vue3-template/index.test.ts
+++ b/test/vue3-template/index.test.ts
@@ -21,5 +21,8 @@ test('should allow to use .pug template file', async ({ page }) => {
 	const button1 = page.locator('#button1');
 	await expect(button1).toHaveText('A: 0');
 
+	const dependencyEl = page.locator('#dependency');
+	await expect(dependencyEl).toHaveText('dependency text');
+
 	await server.close();
 });

--- a/test/vue3-template/src/A.vue
+++ b/test/vue3-template/src/A.vue
@@ -7,12 +7,12 @@ include ./dependency
 import { ref } from 'vue';
 
 export default {
-	setup() {
-		const count = ref(0);
+  setup() {
+    const count = ref(0);
 
-		return {
-			count,
-		};
-	},
+    return {
+      count,
+    };
+  },
 };
 </script>

--- a/test/vue3-template/src/A.vue
+++ b/test/vue3-template/src/A.vue
@@ -1,9 +1,10 @@
 <template lang="pug">
 button#button1(@click='count++') A: {{ count }}
+include ./dependency
 </template>
 
 <script>
-import { ref } from 'vue';
+import { ref } from "vue";
 
 export default {
   setup() {

--- a/test/vue3-template/src/A.vue
+++ b/test/vue3-template/src/A.vue
@@ -4,15 +4,15 @@ include ./dependency
 </template>
 
 <script>
-import { ref } from "vue";
+import { ref } from 'vue';
 
 export default {
-  setup() {
-    const count = ref(0);
+	setup() {
+		const count = ref(0);
 
-    return {
-      count,
-    };
-  },
+		return {
+			count,
+		};
+	},
 };
 </script>

--- a/test/vue3-template/src/dependency.pug
+++ b/test/vue3-template/src/dependency.pug
@@ -1,0 +1,1 @@
+#dependency dependency text


### PR DESCRIPTION
Enhances the Pug plugin by adding dependency tracking when compiling Pug templates.

It uses `compileClientWithDependenciesTracked` to extract all dependencies (such as includes and extends) from the Pug source, and registers them with the build system using `addDependency`. This ensures that changes to any referenced files will trigger rebuilds as expected.

##### `main.pug`

```pug
extends /layout/layout

block main
  div
    | main

  include test
```

Now, changes in all files (main.pug, test.pug, layout.pug), will trigger rebuild.