### PR TITLE
feat: Add page reload on .pug entry rebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build": "rslib build",
 		"dev": "rslib build --watch",
@@ -34,6 +36,7 @@
 	},
 	"dependencies": {
 		"@types/pug": "^2.0.10",
+		"lodash": "^4.17.21",
 		"pug": "^3.0.3",
 		"reduce-configs": "^1.1.0"
 	},
@@ -43,6 +46,7 @@
 		"@rsbuild/core": "1.3.14",
 		"@rsbuild/plugin-vue": "1.0.7",
 		"@rslib/core": "^0.6.8",
+		"@types/lodash": "^4.17.16",
 		"@types/node": "^22.15.3",
 		"nano-staged": "^0.8.0",
 		"playwright": "^1.52.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/pug':
         specifier: ^2.0.10
         version: 2.0.10
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       pug:
         specifier: ^3.0.3
         version: 3.0.3
@@ -33,6 +36,9 @@ importers:
       '@rslib/core':
         specifier: ^0.6.8
         version: 0.6.8(typescript@5.8.3)
+      '@types/lodash':
+        specifier: ^4.17.16
+        version: 4.17.16
       '@types/node':
         specifier: ^22.15.3
         version: 22.15.3
@@ -337,6 +343,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash@4.17.16':
+    resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
 
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
@@ -671,6 +680,9 @@ packages:
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -1200,6 +1212,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/lodash@4.17.16': {}
+
   '@types/node@22.15.3':
     dependencies:
       undici-types: 6.21.0
@@ -1552,6 +1566,8 @@ snapshots:
       promise: 7.3.1
 
   loader-runner@4.3.0: {}
+
+  lodash@4.17.21: {}
 
   magic-string@0.30.17:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,6 @@ export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
 		 */
 		const triggerPageReload = debounce(
 			() => {
-				console.log('triggerPageReload');
 				state.server?.sockWrite('static-changed');
 			},
 			100,


### PR DESCRIPTION
closes #17 

Enhances the Pug plugin by adding page reload when compiling Pug templates.

It uses `server?.sockWrite('static-changed')` [setup-middlewares#sockwrite](https://rsbuild.dev/config/dev/setup-middlewares#sockwrite), to make server to decide what to do next.
