### PR TITLE
fix: dependencies handling

### DIFF
--- a/playground/src/components/dependency.pug
+++ b/playground/src/components/dependency.pug
@@ -1,0 +1,3 @@
+mixin dependency(props = {})
+  .dependency
+    | dependency text

--- a/playground/src/index.pug
+++ b/playground/src/index.pug
@@ -1,2 +1,6 @@
+include ./components/dependency
+
 p(id="test-pug") Pug source code!
 div(id="root")
+
++dependency

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,12 +73,12 @@ export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
 
 		api.onCloseDevServer(() => {
 			state.server = undefined;
+			state.dependencies.clear();
 		});
 
 		// Prevent reload on initial build
 		api.onDevCompileDone(() => {
 			state.readyToReload = true;
-			state.dependencies.clear();
 		});
 
 		api.transform(

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,17 +115,13 @@ export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
 					// Persis dependencies across builds in case is compilation error occurs
 					state.dependencies = new Set(dependencies);
 
-					// Watch all unique dependencies (includes, extends, etc.)
-					for (const dependency of Array.from(state.dependencies)) {
-						addDependency(dependency);
-					}
-
 					if (state.readyToReload === true) {
 						triggerPageReload();
 					}
 
 					return `${body}; export default template;`;
 				} finally {
+					// Watch all unique dependencies (includes, extends, etc.)
 					for (const dependency of Array.from(state.dependencies)) {
 						addDependency(dependency);
 					}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,11 @@ export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
 		const state: {
 			readyToReload: boolean;
 			server?: SetupMiddlewaresServer;
-			dependencies: Set<string>;
+			dependencies: Map<string, Set<string>>;
 		} = {
 			readyToReload: false,
 			server: undefined,
-			dependencies: new Set(),
+			dependencies: new Map(),
 		};
 
 		/**
@@ -110,10 +110,10 @@ export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
 						options,
 					);
 
-					state.dependencies.clear();
+					state.dependencies.delete(resourcePath);
 
-					// Persis dependencies across builds in case is compilation error occurs
-					state.dependencies = new Set(dependencies);
+					// Persis dependencies across builds in case if compilation error occurs
+					state.dependencies.set(resourcePath, new Set(dependencies));
 
 					if (state.readyToReload === true) {
 						triggerPageReload();
@@ -122,7 +122,9 @@ export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
 					return `${body}; export default template;`;
 				} finally {
 					// Watch all unique dependencies (includes, extends, etc.)
-					for (const dependency of Array.from(state.dependencies)) {
+					for (const dependency of Array.from(
+						state.dependencies.get(resourcePath) ?? [],
+					)) {
 						addDependency(dependency);
 					}
 				}


### PR DESCRIPTION
- Fixes dependencies loss on compilation done, caused by dependencies cache were cleared on errors too.
- Fixes cache overlaping when multiple .pug template entries are used