### PR TITLE
fix: update @rsbuild/core peer dependency to >=1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"vue": "^3.5.18"
 	},
 	"peerDependencies": {
-		"@rsbuild/core": "1.x"
+		"@rsbuild/core": ">=1.5.0"
 	},
 	"peerDependenciesMeta": {
 		"@rsbuild/core": {


### PR DESCRIPTION
For the new hook: https://github.com/rspack-contrib/rsbuild-plugin-pug/pull/28/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R68