### PR TITLE
chore: upgrade TypeScript to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,68 +1,70 @@
 {
-	"name": "@rsbuild/plugin-pug",
-	"version": "1.3.2",
-	"repository": "https://github.com/rstackjs/rsbuild-plugin-pug",
-	"license": "MIT",
-	"type": "module",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
-		}
-	},
-	"main": "./dist/index.js",
-	"module": "./dist/index.mjs",
-	"types": "./dist/index.d.ts",
-	"files": ["dist"],
-	"scripts": {
-		"build": "rslib",
-		"dev": "rslib -w",
-		"lint": "biome check .",
-		"lint:write": "biome check . --write",
-		"prepare": "simple-git-hooks && npm run build",
-		"test": "playwright test",
-		"bump": "npx bumpp"
-	},
-	"simple-git-hooks": {
-		"pre-commit": "npx nano-staged"
-	},
-	"nano-staged": {
-		"*.{js,jsx,ts,tsx,mjs,cjs}": [
-			"biome check --write --no-errors-on-unmatched"
-		]
-	},
-	"dependencies": {
-		"@types/pug": "^2.0.10",
-		"lodash": "^4.17.23",
-		"pug": "^3.0.4",
-		"reduce-configs": "^1.1.1"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
-		"@playwright/test": "^1.58.2",
-		"@rsbuild/core": "1.7.3",
-		"@rsbuild/plugin-vue": "1.2.7",
-		"@rslib/core": "^0.20.0",
-		"@types/lodash": "^4.17.24",
-		"@types/node": "^24.12.0",
-		"nano-staged": "^0.9.0",
-		"playwright": "^1.58.2",
-		"simple-git-hooks": "^2.13.1",
-		"typescript": "^5.9.3",
-		"vue": "^3.5.30"
-	},
-	"peerDependencies": {
-		"@rsbuild/core": ">=1.5.0"
-	},
-	"peerDependenciesMeta": {
-		"@rsbuild/core": {
-			"optional": true
-		}
-	},
-	"packageManager": "pnpm@10.32.1",
-	"publishConfig": {
-		"access": "public",
-		"registry": "https://registry.npmjs.org/"
-	}
+  "name": "@rsbuild/plugin-pug",
+  "version": "1.3.2",
+  "repository": "https://github.com/rstackjs/rsbuild-plugin-pug",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rslib",
+    "dev": "rslib -w",
+    "lint": "biome check .",
+    "lint:write": "biome check . --write",
+    "prepare": "simple-git-hooks && npm run build",
+    "test": "playwright test",
+    "bump": "npx bumpp"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx nano-staged"
+  },
+  "nano-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": [
+      "biome check --write --no-errors-on-unmatched"
+    ]
+  },
+  "dependencies": {
+    "@types/pug": "^2.0.10",
+    "lodash": "^4.17.23",
+    "pug": "^3.0.4",
+    "reduce-configs": "^1.1.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@playwright/test": "^1.58.2",
+    "@rsbuild/core": "1.7.3",
+    "@rsbuild/plugin-vue": "1.2.7",
+    "@rslib/core": "^0.20.0",
+    "@types/lodash": "^4.17.24",
+    "@types/node": "^24.12.0",
+    "nano-staged": "^0.9.0",
+    "playwright": "^1.58.2",
+    "simple-git-hooks": "^2.13.1",
+    "typescript": "^6.0.2",
+    "vue": "^3.5.30"
+  },
+  "peerDependencies": {
+    "@rsbuild/core": ">=1.5.0"
+  },
+  "peerDependenciesMeta": {
+    "@rsbuild/core": {
+      "optional": true
+    }
+  },
+  "packageManager": "pnpm@10.32.1",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,10 +32,10 @@ importers:
         version: 1.7.3
       '@rsbuild/plugin-vue':
         specifier: 1.2.7
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@6.0.2))
       '@rslib/core':
         specifier: ^0.20.0
-        version: 0.20.0(core-js@3.47.0)(typescript@5.9.3)
+        version: 0.20.0(core-js@3.47.0)(typescript@6.0.2)
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
@@ -52,11 +52,11 @@ importers:
         specifier: ^2.13.1
         version: 2.13.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.2
+        version: 6.0.2
       vue:
         specifier: ^3.5.30
-        version: 3.5.30(typescript@5.9.3)
+        version: 3.5.30(typescript@6.0.2)
 
 packages:
 
@@ -732,8 +732,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -916,9 +916,9 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@1.7.3)(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@1.7.3)(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@6.0.2))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
+      rspack-vue-loader: 17.5.0(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@6.0.2))
     optionalDependencies:
       '@rsbuild/core': 1.7.3
     transitivePeerDependencies:
@@ -926,12 +926,12 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
-  '@rslib/core@0.20.0(core-js@3.47.0)(typescript@5.9.3)':
+  '@rslib/core@0.20.0(core-js@3.47.0)(typescript@6.0.2)':
     dependencies:
       '@rsbuild/core': 2.0.0-beta.8(core-js@3.47.0)
-      rsbuild-plugin-dts: 0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@5.9.3)
+      rsbuild-plugin-dts: 0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@6.0.2)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
@@ -1110,11 +1110,11 @@ snapshots:
       '@vue/shared': 3.5.30
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.30(vue@3.5.30(typescript@6.0.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.30
       '@vue/shared': 3.5.30
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
   '@vue/shared@3.5.30': {}
 
@@ -1363,20 +1363,20 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rsbuild-plugin-dts@0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@5.9.3):
+  rsbuild-plugin-dts@0.20.0(@rsbuild/core@2.0.0-beta.8(core-js@3.47.0))(typescript@6.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.0-beta.8(core-js@3.47.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3)):
+  rspack-vue-loader@17.5.0(@rspack/core@2.0.0-beta.6(@swc/helpers@0.5.19))(vue@3.5.30(typescript@6.0.2)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
       '@rspack/core': 2.0.0-beta.6(@swc/helpers@0.5.19)
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.30(typescript@6.0.2)
 
   simple-git-hooks@2.13.1: {}
 
@@ -1392,21 +1392,21 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.16.0: {}
 
   void-elements@3.1.0: {}
 
-  vue@3.5.30(typescript@5.9.3):
+  vue@3.5.30(typescript@6.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.30
       '@vue/compiler-sfc': 3.5.30
       '@vue/runtime-dom': 3.5.30
-      '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.30(vue@3.5.30(typescript@6.0.2))
       '@vue/shared': 3.5.30
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   with@7.0.2:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,15 @@
 {
-	"compilerOptions": {
-		"outDir": "./dist",
-		"baseUrl": "./",
-		"target": "ES2020",
-		"lib": ["DOM", "ESNext"],
-		"module": "Node16",
-		"strict": true,
-		"declaration": true,
-		"isolatedModules": true,
-		"esModuleInterop": true,
-		"skipLibCheck": true,
-		"resolveJsonModule": true,
-		"moduleResolution": "Node16"
-	},
-	"include": ["src"]
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "target": "ES2023",
+    "types": ["node"],
+    "lib": ["DOM", "ESNext"],
+    "declaration": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Upgrade TypeScript to `^6.0.2`.
- Replace the root `tsconfig.json` with the shared NodeNext configuration.
- Refresh the lockfile for the new TypeScript range.

## Testing

- `pnpm i`
- `pnpm build`
- `pnpm test` currently hits an unrelated local `localhost:3000` rsbuild dev server, so Playwright opens the wrong page and fails in the `basic` fixture.

## Related Links

- https://github.com/microsoft/TypeScript/releases/tag/v6.0.2
